### PR TITLE
Harden benchmark script against pull request changes

### DIFF
--- a/benchmarks/community-benchmark/run.sh
+++ b/benchmarks/community-benchmark/run.sh
@@ -44,7 +44,7 @@ echo "Use case 1: We want to test the impact of a PR on a branch."
 echo "To run this, declare:"
 echo "The script expects the following variables to be set:"
 echo "CATEGORY = a category of tests to run - folders in benchmark/"
-echo "BRANCH = the branch the test should be based off. e.g. master"
+echo "BASE = the branch the test should be based off. e.g. master"
 echo "PULL_ID = the pull request that contains changes to test"
 echo "TARGET = the SHA of the commit HEAD that contains changes to test"
 echo "-------------------------------------------------------------"
@@ -68,7 +68,7 @@ if [ -z $PULL_ID ]; then
 	mandatory TARGET
 else
 	export USE_CASE=1
-	mandatory BRANCH
+	mandatory BASE
 	mandatory PULL_ID
 	mandatory TARGET
 	assertShaLike TARGET
@@ -87,7 +87,7 @@ case $USE_CASE in
 1)
 	# Validate TARGET and pull request HEAD are consistent
 	assertMatchesPullRequest TARGET PULL_ID
-	git checkout $BRANCH
+	git checkout $BASE
 	;;
 2)
 	git checkout $BASE

--- a/benchmarks/community-benchmark/run.sh
+++ b/benchmarks/community-benchmark/run.sh
@@ -81,7 +81,7 @@ getMACHINE_THREADS=`cat /proc/cpuinfo |grep processor|tail -n1|awk {'print $3'}`
 let getMACHINE_THREADS=getMACHINE_THREADS+1 #getting threads this way is 0 based. Add one
 optional MACHINE_THREADS $getMACHINE_THREADS
 rm -rf node
-git clone https://github.com/nodejs/node.git
+git clone --depth=1 https://github.com/nodejs/node.git
 cd node
 case $USE_CASE in
 1)


### PR DESCRIPTION
Require a new `TARGET` variable specifying the expected SHA of the commit at the HEAD of the pull request when running the benchmark script for pull requests.